### PR TITLE
style: format braces in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,8 @@
 	<span class="highlight-blue">isCoding</span>: 'true',
 	<span class="highlight-blue">drink</span>: ['Coffee',
 		'Tea',
-		'Water']}
+		'Water']
+}
 </pre>
         </div>
       </div>


### PR DESCRIPTION
* Fixes issue #264 
Below is the sample 👇🏻
<img width="1440" alt="Screenshot 2023-09-10 at 12 14 31 AM" src="https://github.com/schmelto/Portfolio/assets/49526472/59e7ead1-feaf-42c1-894e-e17060298447">


